### PR TITLE
fix commands unable to send client-only chat messages

### DIFF
--- a/patches_client/net/minecraft/src/EntityClientPlayerMP.java.patch
+++ b/patches_client/net/minecraft/src/EntityClientPlayerMP.java.patch
@@ -5,7 +5,6 @@
  	private boolean field_9381_bG = false;
  	private int field_12242_bI = 0;
 +	public PlayerHelper ph;
-+	protected Minecraft mc;
  
  	public EntityClientPlayerMP(Minecraft minecraft1, World world2, Session session3, NetClientHandler netClientHandler4) {
  		super(minecraft1, world2, session3, 0);
@@ -14,7 +13,7 @@
  	}
  
  	public boolean canAttackEntity(Entity entity1, int i2) {
-@@ -27,13 +30,78 @@
+@@ -27,13 +29,78 @@
  
  	public void heal(int i1) {
  	}
@@ -93,7 +92,7 @@
  
  	public void func_6420_o() {
  	}
-@@ -125,8 +193,12 @@
+@@ -125,8 +192,12 @@
  		entityItem1.motionZ = (double)packet21PickupSpawn2.roll / 128.0D;
  	}
  
@@ -108,7 +107,7 @@
  	}
  
  	public void func_457_w() {
-@@ -140,6 +212,9 @@
+@@ -140,6 +211,9 @@
  	}
  
  	protected void damageEntity(int i1) {

--- a/patches_client/net/minecraft/src/EntityPlayerSP.java.patch
+++ b/patches_client/net/minecraft/src/EntityPlayerSP.java.patch
@@ -1,0 +1,11 @@
+--- net/minecraft/src/EntityPlayerSP.java
++++ net/minecraft/src/EntityPlayerSP.java
+@@ -4,7 +4,7 @@
+ 
+ public class EntityPlayerSP extends EntityPlayer {
+ 	public MovementInput movementInput;
+-	private Minecraft mc;
++	public Minecraft mc;
+ 
+ 	public EntityPlayerSP(Minecraft var1, World var2, Session var3) {
+ 		super(var2);

--- a/patches_client/net/minecraft/src/PlayerHelper.java.patch
+++ b/patches_client/net/minecraft/src/PlayerHelper.java.patch
@@ -1859,12 +1859,11 @@
 +	}
 +
 +	public void sendMessage(String message) {
-+	}
-+
-+	public void sendMessage(String message, char colour) {
++		this.mc.ingameGUI.addChatMessage(message);
 +	}
 +
 +	public void sendError(String message) {
++		this.mc.ingameGUI.addChatMessage(message);
 +	}
 +
 +	public void printCurrentTime() {


### PR DESCRIPTION
(there is one bit in EntityPlayerSP.java.patch that might require mapping changes so it uses whatever mappings you're using for the other files instead of retromcpjava var1, var2, var3, etc.)